### PR TITLE
Pretty display for describe-bindings.

### DIFF
--- a/smartrep.el
+++ b/smartrep.el
@@ -73,11 +73,16 @@
         (if (eq keymap global-map)
             alist
           (append alist (gethash prefix smartrep-global-alist-hash))))
-  (mapc (lambda(x)
-          (define-key keymap
-            (read-kbd-macro 
-             (concat prefix " " (car x))) (smartrep-map alist)))
-        alist))
+  (let ((oa (make-vector 13 nil)))
+    (mapc (lambda(x)
+	    (let ((obj (intern (prin1-to-string
+				(smartrep-unquote (cdr x)))
+			       oa)))
+	      (fset obj (smartrep-map alist))
+	      (define-key keymap
+		(read-kbd-macro 
+		 (concat prefix " " (car x))) obj)))
+	  alist)))
 (put 'smartrep-define-key 'lisp-indent-function 2)
 
 (defun smartrep-map (alist)


### PR DESCRIPTION
describe-bindings をしたときに "??" になるのをふせぐパッチです。
名前をつけるために新しい obarray を作って intern してるので、ちょっとやりすぎかもしれません。

たとえば以下を定義すると

```
(smartrep-define-key global-map "M-g"
  '(("M-n" . next-error)
    ("n" . (lambda () (next-error)))
    ("M-p" . previous-error)
    ("p" . previous-error)
    ))
```

describe-bindings の結果が以下になります。

```
M-g M-n     next-error
M-g n       (next-error)
M-g M-p     (lambda nil (previous-error))
M-g p       previous-error
```

よろしければ取り込んでくださいませ。
