### PR TITLE
use read-event instead of read-key for compatibility

### DIFF
--- a/smartrep.el
+++ b/smartrep.el
@@ -125,7 +125,7 @@
   (lexical-let ((undo-inhibit-record-point t))
     (unwind-protect
         (while
-            (lexical-let ((evt (read-key)))
+            (lexical-let ((evt (read-event)))
               ;; (eq (or (car-safe evt) evt)
               ;;     (or (car-safe repeat-repeat-char)
               ;;         repeat-repeat-char))


### PR DESCRIPTION
The change 7143c0a93fd258e19c9b3a0a7925f289edaefc79 is performed again.
It seems that old read-key mixed in the source in the change 3ae9a02f1de157840702e606d0eed962f1f2466f.

パッチをあてたときに、read-keyがまぎれこんだみたいなので直しました。
