### PR TITLE
仕様可能なら read-event を使う

### DIFF
--- a/smartrep.el
+++ b/smartrep.el
@@ -49,6 +49,10 @@
 
 (defvar smartrep-key-string nil)
 
+(defvar smartrep-read-event
+  (if (fboundp 'read-event) 'read-event 'read-key)
+  "Function to be used for reading keyboard events.")
+
 (defvar smartrep-mode-line-string nil
   "Mode line indicator for smartrep.")
 
@@ -125,7 +129,7 @@
   (lexical-let ((undo-inhibit-record-point t))
     (unwind-protect
         (while
-            (lexical-let ((evt (read-key)))
+            (lexical-let ((evt (funcall smartrep-read-event)))
               ;; (eq (or (car-safe evt) evt)
               ;;     (or (car-safe repeat-repeat-char)
               ;;         repeat-repeat-char))


### PR DESCRIPTION
read-event が定義されていればそれを使うように変更してみました。

minibuffer に長いキーの羅列が表示されないのが利点かと思います。 また、 read-key だと、 MuMaMo など local map を変更する他の minor mode と相性がわるいっぽいんですが、 read-event だとそれが解消されます。

---

ところで、 smartrep-read-event-loop ですが、気になる点があります。
気になる点を変更すると以下のようになります。注釈の 1.--3. を見てみて下さい。

``` cl
(defun smartrep-read-event-loop (lst)
  ;; 1. dynamical bind にしないとこの設定は効かないのでは?
  (let ((undo-inhibit-record-point t))
    (unwind-protect
        (while
            ;; 2. この lexical-let ももしかしたら let で良いんじゃないかと
            (lexical-let ((evt (funcall smartrep-read-event)))
              ;; (eq (or (car-safe evt) evt)
              ;;     (or (car-safe repeat-repeat-char)
              ;;         repeat-repeat-char))
              (setq smartrep-key-string evt)
              (smartrep-extract-char evt lst))
          (smartrep-do-fun smartrep-key-string lst))
      ;; 3. unwind-protect の中に入れる予定だったのでは?
      ;;    UNWINDFORMS (unwind-protect の2番目以降の引数) が空なのが
      ;;    気になりました。
      (setq unread-command-events (list last-input-event)))))
```

注釈の 1. については lexical-let だと変数名が変わってしまうことが pp-macroexpand-last-sexp などを使えば分かると思います。
