### PR TITLE
Support quitting the repeat mode after calling certain commands

### DIFF
--- a/smartrep.el
+++ b/smartrep.el
@@ -84,10 +84,11 @@
 	    (let ((obj (intern (prin1-to-string
 				(smartrep-unquote (cdr x)))
 			       oa)))
-	      (fset obj (smartrep-map alist stop-events))
-	      (define-key keymap
-		(read-kbd-macro 
-		 (concat prefix " " (car x))) obj)))
+              (unless (member (car x) stop-keys)
+                (fset obj (smartrep-map alist stop-events))
+                (define-key keymap
+                  (read-kbd-macro 
+                   (concat prefix " " (car x))) obj))))
 	  alist)))
 (put 'smartrep-define-key 'lisp-indent-function 2)
 


### PR DESCRIPTION
I have a minor mode and a command that I'd like to able to skip the prefix on (if it's called after other commands from that minor mode, of course), but the command opens a new window and shows a different buffer, in which the minor mode commands don't make sense.
So I'd like smartrep to quit the repeat mode after that command is called.

Here's an implementation that works for me, but you still may want to check the case when the `(vectorp rkm)` check in `smartrep-key-to-number` returns `nil`.

If the approach with adding a new argument to `smartrep-define-key` looks too messy for you, I can reimplement the same functionality using a property on the command name symbol:

``` lisp
(put command 'smartrep-stop t)
```
