### PR TITLE
Change for updating mode-line

### DIFF
--- a/smartrep.el
+++ b/smartrep.el
@@ -110,8 +110,9 @@
   (interactive)
   (setq smartrep-mode-line-string smartrep-mode-line-string-activated)
   (let ((ml-original-bg (face-background 'mode-line)))
-      (set-face-background 'mode-line smartrep-mode-line-active-bg)
-      (force-mode-line-update)
+      (when smartrep-mode-line-active-bg
+        (set-face-background 'mode-line smartrep-mode-line-active-bg)
+        (force-mode-line-update))
       (setq smartrep-original-position (cons (point) (window-start)))
       (unwind-protect
           (let ((repeat-repeat-char last-command-event))
@@ -119,8 +120,9 @@
             (when repeat-repeat-char
               (smartrep-read-event-loop lst)))
         (setq smartrep-mode-line-string "")
-        (set-face-background 'mode-line ml-original-bg)
-        (force-mode-line-update))))
+        (when smartrep-mode-line-active-bg
+          (set-face-background 'mode-line ml-original-bg)
+          (force-mode-line-update)))))
 
 (defun smartrep-read-event-loop (lst)
   (lexical-let ((undo-inhibit-record-point t))


### PR DESCRIPTION
Don't call force-mode-line-update if its color is nil.
I think that it is enough for someone to change mode-line string.
