### PR TITLE
Update smartrep.el for v30.1 compat

### DIFF
--- a/smartrep.el
+++ b/smartrep.el
@@ -89,7 +89,7 @@
         (if (eq keymap global-map)
             alist
           (append alist (gethash prefix smartrep-global-alist-hash))))
-  (let ((oa (make-vector 13 nil)))
+  (let ((oa (make-vector 13 0)))
     (mapc (lambda(x)
 	    (let ((obj (intern (prin1-to-string
 				(smartrep-unquote (cdr x)))


### PR DESCRIPTION
Compat with emacs 30.1 requires that vectors to be used as obarrays to be initialized with 0, not nil.